### PR TITLE
Fix Defaults and Better Format JSON

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,7 +1,6 @@
 const DEFAULT_PARAMS = [
   'auth',
   'bearer',
-  'CC',
   'credit',
   'CVD',
   'CVV',
@@ -9,7 +8,6 @@ const DEFAULT_PARAMS = [
   'PAN',
   'pass',
   'secret',
-  'secur',
   'token'
 ]
 

--- a/src/sensitiveParamFilter.js
+++ b/src/sensitiveParamFilter.js
@@ -40,7 +40,7 @@ class SensitiveParamFilter {
     try {
       const parsed = JSON.parse(input)
       const filtered = this.recursiveFilter(parsed)
-      return JSON.stringify(filtered)
+      return JSON.stringify(filtered, null, 1)
     } catch (error) {
       return input
     }


### PR DESCRIPTION
Remove 'CC' (collides with Accept) and 'secur' (collides with strict-transport-security) default filters, and make JSON output more readable by adding 1 space whitespace