### PR TITLE
Fix package.json to point to org and minor documentation fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 Please follow the appropriate template when opening an issue or pull request:
 
  * [PR Template](.github/PULL_REQUEST_TEMPLATE.md)
- * [Bug Report Template](.github/ISSUE_TEMPLATES/bug_report.md)
- * [Feature Request Template](.github/ISSUE_TEMPLATES/feature_request.md)
+ * [Bug Report Template](.github/ISSUE_TEMPLATE/bug_report.md)
+ * [Feature Request Template](.github/ISSUE_TEMPLATE/feature_request.md)
 
 Understand that it may take several days for your contribution to be reviewed (in particular if you open it on a weekend).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "sensitive-param-filter",
-  "version": "1.0.0",
+  "name": "@amaabca/sensitive-param-filter",
+  "version": "1.0.1",
   "description": "A package for filtering sensitive data (parameters, keys) from a variety of JS objects",
   "main": "src/index.js",
   "author": "Alberta Motor Association",


### PR DESCRIPTION
**Is this PR a bug fix, new feature, or security update?** bug fix

**Do you understand and accept that your contribution will be released under an MIT license?** yes

**Please describe this pull request:**
I accidentally published this to my own npm instead of @amaabca - fixed in package.json
CONTRIBUTING.md was pointing to the wrong place for templates - fixed

**PR Review Checklist**

* [x] I have passing tests run via `yarn test` with a 100% coverage threshold
* [x] I have updated the version in `package.json`
* [x] I have updated any relevant documentation in `README.md`, `.github`, etc.
* [x] I have not included any secret values or links to internal AMA URLs in my commits or PR message
