### PR TITLE
Add code & documentation for publishing to both github packages and npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@ node_modules
 coverage
 test
 .github
+.publish-config
 
 .vscode
 .eslintrc.json

--- a/.publish-config/github.npmrc
+++ b/.publish-config/github.npmrc
@@ -1,0 +1,1 @@
+@amaabca:registry=https://npm.pkg.github.com

--- a/.publish-config/npm.npmrc
+++ b/.publish-config/npm.npmrc
@@ -1,0 +1,1 @@
+@amaabca:registry=https://registry.npmjs.org/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,4 +24,7 @@ Understand that it may take several days for your contribution to be reviewed (i
 
 #### Publishing
 
-For maintainers, use `yarn publish` (ensure `master` is checked out) to publish new versions to `npm`.
+`sensitive-param-filter` is published to both `GitHub Packages` and `npm`. Ensure you are authenticated with both:
+* [GitHub Packages](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-npm-for-use-with-github-packages#authenticating-to-github-packages)
+* [npm](https://docs.npmjs.com/cli/adduser.html)
+Use `yarn release` (ensure `master` is checked out) to publish new versions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaabca/sensitive-param-filter",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A package for filtering sensitive data (parameters, keys) from a variety of JS objects",
   "main": "src/index.js",
   "author": "Alberta Motor Association",
@@ -29,6 +29,11 @@
   "scripts": {
     "lint": "eslint ./src ./test",
     "pretest": "yarn lint",
+    "postrelease:github": "rm .npmrc",
+    "postrelease:npm": "rm .npmrc",
+    "release": "yarn release:github && yarn release:npm",
+    "release:github": "cp .publish-config/github.npmrc .npmrc && npm publish",
+    "release:npm": "cp .publish-config/npm.npmrc .npmrc && npm publish",
     "test": "jest --coverage"
   },
   "jest": {


### PR DESCRIPTION
**Is this PR a bug fix, new feature, or security update?**
None of the above - changes to publish configuration

**Do you understand and accept that your contribution will be released under an MIT license?**
Yes

**Please describe this pull request:**
 - Add code & documentation for publishing to both github packages and npm
 - I made a boo-boo and originally had `yarn publish --dry-run` in both of the `release` commands - well, it turns out `yarn publish` doesn't support the `--dry-run` option, so 1.0.6 is already released. I've switched to using the `npm publish` command for another reason: it just publishes the version in `package.json` instead of requiring you to input a version in the CLI.

**PR Review Checklist**

* [x] I have passing tests run via `yarn test` with a 100% coverage threshold
* [x] I have updated the version in `package.json`
* [x] I have updated any relevant documentation in `README.md`, `.github`, etc.
* [x] I have not included any secret values or links to internal AMA URLs in my commits or PR message