### PR TITLE
fix: stop big numbers in strings from being rounded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaabca/sensitive-param-filter",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A package for filtering sensitive data (parameters, keys) from a variety of JS objects",
   "main": "src/index.js",
   "author": "Alberta Motor Association",

--- a/src/sensitiveParamFilter.js
+++ b/src/sensitiveParamFilter.js
@@ -45,6 +45,9 @@ class SensitiveParamFilter {
   filterString(input) {
     try {
       const parsed = JSON.parse(input)
+      if (typeof parsed === 'number') {
+        return input
+      }
       const filtered = this.recursiveFilter(parsed)
       return JSON.stringify(filtered)
     } catch (error) {

--- a/test/sensitiveParamFilter.test.js
+++ b/test/sensitiveParamFilter.test.js
@@ -417,5 +417,13 @@ describe('SensitiveParamFilter', () => {
         expect(output).toBeNull()
       })
     })
+
+    describe('filtering large integers in strings', () => {
+      it('returns the same value without rounding it', () => {
+        const bigInt = '987654321987654321'
+        const output = paramFilter.filter(bigInt)
+        expect(output).toEqual(bigInt)
+      })
+    })
   })
 })


### PR DESCRIPTION
**Is this PR a bug fix, new feature, or security update?**
Bug fix.

**Do you understand and accept that your contribution will be released under an MIT license?**
Yes.

**Please describe this pull request:**
A string that is a big number, e.g. `'987654321987654321'`, was being rounded if it is bigger than [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). The reason this was happening in this library is because `JSON.parse('987654321987654321')` returns a rounded number of `987654321987654300`.

This PR will add a check when parsing a string. If the parsed type is a number, it will return it immediately, rather than continuing to filter it recursively.

**PR Review Checklist**

* [x] I have passing tests run via `yarn test` with a 100% coverage threshold
* [x] I have updated the version in `package.json`
* [x] I have updated any relevant documentation in `README.md`, `.github`, etc.
* [x] I have not included any secret values or links to internal AMA URLs in my commits or PR message
