### PR TITLE
ADO 34638 - Fix CD

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -17,10 +17,10 @@ jobs:
           name: artifacts
           path: src/
 
-  publish-package:
+  publish-package-to-github:
     runs-on: macos-latest
     needs: install
-    name: publish to github packages and npm
+    name: publish to github packages
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -37,6 +37,19 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-package-to-npm:
+    runs-on: macos-latest
+    needs: install
+    name: publish to npm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download built artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: artifacts
+          path: src
       - uses: actions/setup-node@v2
         with:
           node-version: '14.x'


### PR DESCRIPTION
**Is this PR a bug fix, new feature, or security update?**
CD fix

**Do you understand and accept that your contribution will be released under an MIT license?**
I get it

**Please describe this pull request:**
Split the publish steps into 2 because the github actions do not seem to be able to use the different url for the repo once one is set, and so it was unable to deploy npm.

**PR Review Checklist**

- [x] I have passing tests run via `npm run test` with a 100% coverage threshold
- [x] I have updated the version in `package.json`
- [x] I have updated any relevant documentation in `README.md`, `.github`, etc.
- [x] I have not included any secret values or links to internal AMA URLs in my commits or PR message
