### PR TITLE
Fix map and set filtering

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install correct npm version 8
-        run: npm -g install npm@8
+        run: npm -g install npm@8.3.1
       - name: npm install
         run: npm install
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install correct npm version 8
-        run: npm -g install npm@8
+        run: npm -g install npm@8.3.1
       - name: Install dependencies
         run: npm install
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -49,21 +49,27 @@ Key matching is done in a case-insensitive, partial-macthing manner (that is, if
 
  * Does not modify input objects
  * Performs a deep copy of the input object (note that booleans, numbers, and strings - which are immutable - are technically copied by reference)
- * Does not copy functions
+ * Can be configued to filter out or leave "unexpected" objects (such as functions)
  * Handles circular references
  * Filters valid JSON strings
  * Filters valid and malformed URL query params
+ * Filters Errors, Arrays, Maps, Sets, and simple objects
 
 ### Options
 
 ```js
 const { SPFDefaultParams, SensitiveParamFilter } = require('@amaabca/sensitive-param-filter')
 const filter = new SensitiveParamFilter({
+  filterUnknown: false,
   params: SPFDefaultParams.concat(['data', 'email']),
   replacement: '***',
   whitelist: ['authentic', 'encryption_standard']
 })
 ```
+
+* **filterUnknown:**
+Indicates whether "unexpected" objects (such as functions) should be filtered or returned as-is.
+Defaults to `true`
 
 * **params:**
 An array of string params to filter.
@@ -72,7 +78,7 @@ Setting this option overwrites the default array (`SPFDefaultParams`).
 
 * **replacement:**
 The object to replace filtered values with.
-By default, replacement is `'FILTERED'`.
+Defaults to `'FILTERED'`.
 
 * **whitelist:**
 An array of strings to exclude from filtering.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaabca/sensitive-param-filter",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A package for filtering sensitive data (parameters, keys) from a variety of JS objects",
   "engines": {
     "npm": ">=8"

--- a/src/sensitiveParamFilter.js
+++ b/src/sensitiveParamFilter.js
@@ -12,6 +12,7 @@ const {
 
 class SensitiveParamFilter {
   constructor(args = {}) {
+    this.filterUnknown = args.filterUnknown || true
     this.paramRegex = constructParamRegex(args.params || DEFAULT_PARAMS)
     this.replacement = args.replacement || DEFAULT_REPLACEMENT
     this.whitelistRegex = constructWhitelistRegex(args.whitelist)
@@ -48,7 +49,10 @@ class SensitiveParamFilter {
       return this.filterObject(input)
     }
 
-    return null
+    if (this.filterUnknown) {
+      return this.replacement
+    }
+    return input
   }
 
   filterString(input) {

--- a/src/sensitiveParamFilter.js
+++ b/src/sensitiveParamFilter.js
@@ -27,6 +27,11 @@ class SensitiveParamFilter {
   }
 
   recursiveFilter(input) {
+    const id = input[this.objectIdKey]
+    if (id || id === 0) {
+      return this.examinedObjects[id].copy
+    }
+
     if (!input || typeof input === 'number' || typeof input === 'boolean') {
       return input
     } else if (typeof input === 'string' || input instanceof String) {
@@ -35,6 +40,10 @@ class SensitiveParamFilter {
       return this.filterError(input)
     } else if (Array.isArray(input)) {
       return this.filterArray(input)
+    } else if (input instanceof Map) {
+      return this.filterMap(input)
+    } else if (input instanceof Set) {
+      return this.filterSet(input)
     } else if (typeof input === 'object') {
       return this.filterObject(input)
     }
@@ -68,11 +77,6 @@ class SensitiveParamFilter {
   }
 
   filterError(input) {
-    const id = input[this.objectIdKey]
-    if (id || id === 0) {
-      return this.examinedObjects[id].copy
-    }
-
     const copy = new Error(input.message)
     Object.defineProperties(copy, {
       name: {
@@ -101,10 +105,6 @@ class SensitiveParamFilter {
   }
 
   filterObject(input) {
-    const id = input[this.objectIdKey]
-    if (id || id === 0) {
-      return this.examinedObjects[id].copy
-    }
     const copy = { ...input }
     this.saveCopy(input, copy)
     this.recursivelyFilterAttributes(copy)
@@ -112,15 +112,44 @@ class SensitiveParamFilter {
   }
 
   filterArray(input) {
-    const id = input[this.objectIdKey]
-    if (id || id === 0) {
-      return this.examinedObjects[id].copy
-    }
     const copy = []
     this.saveCopy(input, copy)
     for (const item of input) {
       copy.push(this.recursiveFilter(item))
     }
+    return copy
+  }
+
+  filterMap(input) {
+    const copy = new Map()
+    const iterator = input.entries()
+    let result = iterator.next()
+    while (!result.done) {
+      const [key, value] = result.value
+      if (typeof key === 'string' || key instanceof String) {
+        if (!this.whitelistRegex.test(key) && this.paramRegex.test(key)) {
+          copy.set(key, this.replacement)
+        } else {
+          copy.set(key, this.recursiveFilter(value))
+        }
+      } else {
+        copy.set(this.recursiveFilter(key), this.recursiveFilter(value))
+      }
+      result = iterator.next()
+    }
+    this.saveCopy(input, copy)
+    return copy
+  }
+
+  filterSet(input) {
+    const copy = new Set()
+    const iterator = input.values()
+    let result = iterator.next()
+    while (!result.done) {
+      copy.add(this.recursiveFilter(result.value))
+      result = iterator.next()
+    }
+    this.saveCopy(input, copy)
     return copy
   }
 

--- a/src/sensitiveParamFilter.js
+++ b/src/sensitiveParamFilter.js
@@ -12,7 +12,11 @@ const {
 
 class SensitiveParamFilter {
   constructor(args = {}) {
-    this.filterUnknown = args.filterUnknown || true
+    if (args.filterUnknown === false) {
+      this.filterUnknown = false
+    } else {
+      this.filterUnknown = true
+    }
     this.paramRegex = constructParamRegex(args.params || DEFAULT_PARAMS)
     this.replacement = args.replacement || DEFAULT_REPLACEMENT
     this.whitelistRegex = constructWhitelistRegex(args.whitelist)

--- a/test/sensitiveParamFilter.test.js
+++ b/test/sensitiveParamFilter.test.js
@@ -8,7 +8,8 @@ describe('SensitiveParamFilter', () => {
       auth: 'auth',
       data: 'data',
       moredata: 'moredata',
-      pass: 'pass'
+      pass: 'pass',
+      someFunction: () => {} // eslint-disable-line no-empty-function
     }
 
     it('uses default values when no arguments are given', () => {
@@ -19,10 +20,12 @@ describe('SensitiveParamFilter', () => {
       expect(output.data).toBe('data')
       expect(output.moredata).toBe('moredata')
       expect(output.pass).toBe('FILTERED')
+      expect(output.someFunction).toBe('FILTERED')
     })
 
     it('uses arguments when they are provided', () => {
       const paramFilter = new SensitiveParamFilter({
+        filterUnknown: false,
         params: ['data'],
         replacement: '***',
         whitelist: ['moredata']
@@ -33,6 +36,7 @@ describe('SensitiveParamFilter', () => {
       expect(output.data).toBe('***')
       expect(output.moredata).toBe('moredata')
       expect(output.pass).toBe('pass')
+      expect(output.someFunction).toBe(input.someFunction)
     })
   })
 
@@ -402,19 +406,6 @@ describe('SensitiveParamFilter', () => {
 
         expect(outputIndex3Object.amount).toBe(9.75)
         expect(outputIndex3Object.credit_card_number).toBe('FILTERED')
-      })
-    })
-
-    describe('filtering functions', () => {
-      const input = () => {} // eslint-disable-line no-empty-function
-
-      let output = null
-      beforeEach(() => {
-        output = paramFilter.filter(input)
-      })
-
-      it('returns null', () => {
-        expect(output).toBeNull()
       })
     })
 


### PR DESCRIPTION
**Is this PR a bug fix, new feature, or security update?**
2 x Bug fix + small new feature

**Do you understand and accept that your contribution will be released under an MIT license?**
Yessir

**Please describe this pull request:**
- Fix filtering of `Maps` and `Sets` - addresses #44
- Add `filterUnknown` parameter that allows `SensitiveParamFilter` to leave values it can't handle
   - before, these values were always converted to `null` - now they will either be filtered or left as-is, depending on `filterUnknown`
   - defaults to `true`
- Fix bug that prevented CI / CD from running

**PR Review Checklist**

- [x] I have passing tests run via `npm run test` with a 100% coverage threshold
- [x] I have updated the version in `package.json`
- [x] I have updated any relevant documentation in `README.md`, `.github`, etc.
- [x] I have not included any secret values or links to internal AMA URLs in my commits or PR message
