### PR TITLE
Renovate config: ensure all updates are grouped together, not just node updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,9 +13,7 @@
     },
     {
       "enabled": true,
-      "excludePackageNames": ["node"],
       "groupName": "All Dependencies",
-      "matchManagers": ["npm"],
       "matchPackagePatterns": ["*"],
       "separateMajorMinor": false
     }


### PR DESCRIPTION
**Is this PR a bug fix, new feature, or security update?**

CI fix

**Do you understand and accept that your contribution will be released under an MIT license?**

Yes

**Please describe this pull request:**

Renovate config: Ensure all updates are grouped together, not just node updates
See https://docs.renovatebot.com/configuration-options/#excludepackagenames and https://docs.renovatebot.com/configuration-options/#matchmanagers

**PR Review Checklist**

- [x] I have passing tests run via `npm run test` with a 100% coverage threshold
- [ ] I have updated the version in `package.json`
- [x] I have updated any relevant documentation in `README.md`, `.github`, etc.
- [x] I have not included any secret values or links to internal AMA URLs in my commits or PR message
