### PR TITLE
ADO 60133: Stop logging Bearer token when it's in a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaabca/sensitive-param-filter",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A package for filtering sensitive data (parameters, keys) from a variety of JS objects",
   "engines": {
     "npm": ">=8"
@@ -25,7 +25,8 @@
   "scripts": {
     "lint": "eslint ./src ./test",
     "pretest": "npm run lint",
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "test:watch": "jest --watchAll=true --coverage=false"
   },
   "jest": {
     "collectCoverage": true,

--- a/test/sensitiveParamFilter.test.js
+++ b/test/sensitiveParamFilter.test.js
@@ -48,6 +48,7 @@ describe('SensitiveParamFilter', () => {
     describe('filtering a plain JS object', () => {
       const input = {
         Authorization: 'Bearer somedatatoken',
+        _header: 'GET /some/items\\nAuthorization: Bearer someheadertoken',
         body: {
           'Private-Data': 'somesecretstuff',
           info: '{ "first_name": "Bob", "last_name": "Bobbington", "PASSWORD": "asecurepassword1234", "amount": 4 }',
@@ -100,6 +101,7 @@ describe('SensitiveParamFilter', () => {
         expect(output.password).toBe('FILTERED')
         expect(output.Authorization).toBe('FILTERED')
         expect(output.body['Private-Data']).toBe('FILTERED')
+        expect(output._header).toBe('FILTERED')
       })
 
       it('filters out JSON keys (case-insensitive) and matches partials while maintaining non-sensitive data', () => {


### PR DESCRIPTION
**Is this PR a bug fix, new feature, or security update?**
Bug Fix: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/60133

**Do you understand and accept that your contribution will be released under an MIT license?**
Yes.

**Please describe this pull request:**
There is still a case when bearer tokens are being logged. See [Rollbar search](https://ama.loggly.com/search#terms=%20%22Bearer%20eyJ%22&from=2023-01-14T19:35:30.475Z&until=2023-01-19T19:35:30.475Z&source_group=). The header gets dumped out as a string, which we don't parse through.

- Add test case for a field with a string containing a filterable value. TDD!
- Handle the case when it's just a string with the offending values in it. This may filter things we don't want filtered (a string that just happens to include a disallowed word), but better that than letting tokens slip through.
- Add shouldFilter helper to wrap the whitelist + params logic.
- Refactor forEach with else-ifs to map with returns, to make it more readable.
- Add test:watch script.
- Bump version.

**PR Review Checklist**
- [x] I have passing tests run via `npm run test` with a 100% coverage threshold
- [x] I have updated the version in `package.json`
- [x] I have updated any relevant documentation in `README.md`, `.github`, etc.
- [x] I have not included any secret values or links to internal AMA URLs in my commits or PR message
