### PR TITLE
Split registry publishing to separate workflows

### DIFF
--- a/.github/workflows/cd-workflow-gh.yml
+++ b/.github/workflows/cd-workflow-gh.yml
@@ -1,13 +1,9 @@
-name: Deploy to NPM Packages
+name: Deploy to Github Packages
 
 on:
   push:
     branches:
       - master
-
-permissions:
-  id-token: write  # Required for OIDC
-  contents: read
 
 jobs:
   install:
@@ -23,10 +19,10 @@ jobs:
           name: artifacts
           path: src/
 
-  publish-package-to-npm:
+  publish-package-to-github:
     runs-on: macos-latest
     needs: install
-    name: publish to npm
+    name: publish to github packages
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,6 +35,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Publish to NPM
+          registry-url: 'https://npm.pkg.github.com'
+      - name: Publish to Github Packages
         run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amaabca/sensitive-param-filter",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amaabca/sensitive-param-filter",
-      "version": "1.2.11",
+      "version": "1.2.12",
       "license": "MIT",
       "devDependencies": {
         "eslint": "8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaabca/sensitive-param-filter",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "A package for filtering sensitive data (parameters, keys) from a variety of JS objects",
   "main": "src/index.js",
   "author": "Alberta Motor Association",


### PR DESCRIPTION
**Is this PR a bug fix, new feature, or security update?**

The last change didn't deploy to either registry. We haven't deployed an update in [over a year](https://github.com/amaabca/sensitive-param-filter/pull/70), so some permissions may have changed since then.

Otherwise, it's possible the OIDC is being applied to both calls, breaking the GitHub publish. I'm not sure what's wrong with the npmjs OIDC.

**Please describe this pull request:**

Split publish to GitHub workflow, so it doesn't try to use the same auth for both.

**PR Review Checklist**

- [ ] I have passing tests run via `npm run test` with a 100% coverage threshold
- [ ] I have updated the version in `package.json`
- [ ] I have updated any relevant documentation in `README.md`, `.github`, etc.
- [ ] I have not included any secret values or links to internal AMA URLs in my commits or PR message
