### PR TITLE
Add "packages: write" permission

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -6,8 +6,9 @@ on:
       - master
 
 permissions:
-  id-token: write  # Required for OIDC
   contents: read
+  id-token: write # Required for OIDC
+  packages: write
 
 jobs:
   install:


### PR DESCRIPTION
**Is this PR a bug fix, new feature, or security update?**
- The last change [didn't deploy](https://github.com/amaabca/sensitive-param-filter/actions/runs/18572708414) to either registry, due to a permission error. We haven't deployed an update in [over a year](https://github.com/amaabca/sensitive-param-filter/pull/70).

**Do you understand and accept that your contribution will be released under an MIT license?**
- Yes.

**Please describe this pull request:**
- Add `packages: write` permission, so it can write to the GitHub registry.

**PR Review Checklist**

- [x] I have passing tests run via `npm run test` with a 100% coverage threshold
- ~[ ] I have updated the version in `package.json`~ (previous update didn't deploy, so this is the same effective version)
- [x] I have updated any relevant documentation in `README.md`, `.github`, etc.
- [x] I have not included any secret values or links to internal AMA URLs in my commits or PR message
