### PR TITLE
Add Type Definitions to Sensitive Param Filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amaabca/sensitive-param-filter",
-  "version": "1.2.11",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amaabca/sensitive-param-filter",
-      "version": "1.2.11",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "eslint": "8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@amaabca/sensitive-param-filter",
-  "version": "1.2.11",
+  "version": "1.3.0",
   "description": "A package for filtering sensitive data (parameters, keys) from a variety of JS objects",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "author": "Alberta Motor Association",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "jest": {
     "collectCoverage": true,
     "collectCoverageFrom": [
-      "src/**"
+      "src/**",
+      "!src/**/*.d.ts"
     ],
     "coverageDirectory": "coverage",
     "coverageThreshold": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,61 @@
+/**
+ * Options for configuring the SensitiveParamFilter.
+ */
+export interface SensitiveParamFilterOptions {
+  /**
+   * Indicates whether "unexpected" objects (such as functions) should be filtered or returned as-is.
+   * Defaults to `true`.
+   */
+  filterUnknown?: boolean;
+
+  /**
+   * An array of string params to filter.
+   * These entries will be combined into a regex that is used by sensitive-param-filter.
+   * Setting this option overwrites the default array (`SPFDefaultParams`).
+   */
+  params?: string[];
+
+  /**
+   * The object to replace filtered values with.
+   * Defaults to `'FILTERED'`.
+   */
+  replacement?: string;
+
+  /**
+   * An array of strings to exclude from filtering.
+   * For example, if `pass_through` is included in the whitelist, the key `pass_through` will not be filtered.
+   * Note that entries must match keys exactly to prevent filtering.
+   */
+  whitelist?: string[];
+}
+
+/**
+ * Class for filtering sensitive parameters from objects.
+ */
+export class SensitiveParamFilter {
+  constructor(args?: SensitiveParamFilterOptions);
+
+  /**
+   * Filters sensitive parameters from the input object.
+   * @param inputObject The object to filter.
+   * @returns A new object with sensitive parameters filtered.
+   */
+  filter<T = any>(inputObject: T): T;
+
+  /**
+   * Checks if a given text should be filtered based on the configured parameters and whitelist.
+   * @param text The text to check.
+   * @returns True if the text should be filtered, false otherwise.
+   */
+  shouldFilter(text: string): boolean;
+}
+
+/**
+ * Default parameters to filter.
+ */
+export const SPFDefaultParams: string[];
+
+/**
+ * Default replacement value for filtered parameters.
+ */
+export const SPFDefaultReplacement: string;


### PR DESCRIPTION
**Is this PR a bug fix, new feature, or security update?**
This is a new feature so we can utilize ESM imports for those who need it.

**Do you understand and accept that your contribution will be released under an MIT license?**
Yes

**Please describe this pull request:**

Increments the version number to 1.3.0 since it adds new functionality, it doesn't quite fit a patch version.  But it adds a type definition for this repo.

**PR Review Checklist**

- [x] I have passing tests run via `npm run test` with a 100% coverage threshold
- [x] I have updated the version in `package.json`
- [x] I have updated any relevant documentation in `README.md`, `.github`, etc.
- [x] I have not included any secret values or links to internal AMA URLs in my commits or PR message
